### PR TITLE
chore(ci): also run workflows on main branch

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -1,6 +1,9 @@
 ---
 name: Ansible CI
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
 jobs:
   ansible:
     uses: famedly/github-workflows/.github/workflows/ansible.yml@ansible-v1


### PR DESCRIPTION
We're only running workflows on PRs to avoid duplicating them, but they should also run after they've been merged so that we can see on the landing page of a repo what the CI state is on the main branch.
