### PR TITLE
chore(ci): add workflow to add issues to infra project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,11 @@
+name: Add issues to Infrastructure Project.
+
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add-to-project:
+    uses: famedly/github-workflows/.github/workflows/add-to-project@github-v1
+    with:
+      project-url: https://github.com/orgs/famedly/projects/6


### PR DESCRIPTION
See https://github.com/famedly/github-workflows/issues/1

No idea how to properly test this before merging, but I think this should be right.

I'll do the PRs for the other repos once we know this actually works the way it's supposed to.

