### PR TITLE
feat(user): remove home directory of removed users

### DIFF
--- a/roles/user/tasks/user.yml
+++ b/roles/user/tasks/user.yml
@@ -15,6 +15,7 @@
     password_lock: "{{ user.attrs.password_lock | default(omit) }}"
     uid: "{{ user.attrs.uid | default(omit) }}"
     state: "{{ user.attrs.active | default(false) | ternary('present', 'absent') }}"
+    remove: true
   become: true
 
 - name: "Ensure ssh keys for {{ user.name }} are up to date"


### PR DESCRIPTION
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html#parameter-remove

> This only affects state=absent, it attempts to remove directories associated with the user.
The behavior is the same as userdel --remove, check the man page for details and support.

I think it should be fine to just simply set this to true, because it is ignored in all cases other than user removal anyways.

Closes https://github.com/famedly/ansible-collection-base/issues/173