### PR TITLE
fix(lego): install acl package to allow becoming an unprivileged user

### DIFF
--- a/roles/lego/defaults/main.yml
+++ b/roles/lego/defaults/main.yml
@@ -94,3 +94,4 @@ lego_dependencies:
       - "python3-cryptography"
     all:
       - "python3-cryptography"
+      - "acl"


### PR DESCRIPTION
Without the ACL package installed, becoming an unprivileged ansible user with an unprivileged connection user is not possible, as it results in an 'invalid mode' error in chmod.