### PR TITLE
feat(restic): add ansible role to run restic in systemd jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ to build services on.
 - [`roles/dropbear_luks_unlock`](roles/dropbear_luks_unlock/README.md) for setting up dropbear to unlock LUKS volumes using a SSH connection at boot
 - [`roles/hostname`](roles/hostname/README.md) for setting `/etc/hostname` and `/etc/hosts`
 - [`roles/ldap`](roles/ldap/README.md) to deploy openldap in a docker container
+- [`roles/restic`](roles/restic/README.md) to configure backups using restic controlled by systemd
 - [`roles/redis`](roles/redis/README.md) to deploy redis in a docker container
 - [`roles/ssh`](roles/ssh/README.md) for SSH hardening
 - [`roles/user`](roles/user/README.md) for creating user accounts with SSH keys deployed

--- a/playbooks/restic.yml
+++ b/playbooks/restic.yml
@@ -1,0 +1,6 @@
+---
+- name: Install and configure restic
+  hosts: "{{ restic_hosts | default('restic') }}"
+  become: true
+  roles:
+    - role: famedly.base.restic

--- a/roles/restic/README.md
+++ b/roles/restic/README.md
@@ -1,0 +1,38 @@
+# `famedly.base.restic` ansible role
+
+Ansible role to download restic and install a systemd
+service and timer to automatically create backups on
+a schedule.
+
+## Setting up backups
+
+Set the restic (remote) repository by populating `restic_repository`
+in the same form as the restic command line argument (f.ex.:
+`s3:https://s3.server.tld/my-bucket/my-specific-restic-repo`).
+
+Set the `restic_password` variable to the password the backup should
+be encrypted with.
+
+If your restic remote needs additional environment variables (like
+`AWS_ACCESS_KEY_ID` etc for s3), set those as `{ENV_VAR_NAME: value}`
+in `restic_environment`.
+
+To control what and how data is backed up, see:
+
+- `restic_backup_paths`: takes an array of paths that should
+  be backed up.
+- `restic_backup_commands`: takes an array of dictionaries of
+  the form `{command, filename}`, where the output of `command`
+  is fed into `restic backup --stdin --stdin-filename {{ filename }}`.
+
+To control when backups are run, see `restic_systemd_timer_on_calendar`
+and `restic_systemd_timer_accuray_sec`.
+
+## Installing restic
+
+The role will attempt to install restic from the github release by default,
+afterwards restic will be available in `/usr/local/bin/restic`.
+
+If restic is already installed or will be installed by another service,
+`restic_install_binary: false` can be set. If the restic binary is not
+located in `/usr/local/bin/restic`, set the full path in `restic_binary`.

--- a/roles/restic/defaults/main.yml
+++ b/roles/restic/defaults/main.yml
@@ -1,0 +1,64 @@
+---
+
+restic_version: "0.16.0"
+restic_job_description: "Run restic backup job"
+restic_binary: "/usr/local/bin/restic"
+
+restic_repository: ~
+restic_password: ~
+
+restic_backup_paths: []
+restic_backup_commands: []
+
+restic_systemd_user: root
+restic_systemd_unit_name: "restic"
+restic_systemd_service_name: "{{ restic_systemd_unit_name }}.service"
+restic_systemd_timer_name: "{{ restic_systemd_unit_name }}.timer"
+restic_systemd_unit_file_directory: "/etc/systemd/system"
+restic_systemd_working_directory: "/tmp"
+restic_systemd_syslog_identifier: "{{ restic_systemd_unit_name }}"
+
+restic_systemd_timer_on_calendar: daily
+restic_systemd_timer_accuracy_sec: 3600
+restic_systemd_timer_persistent: true
+restic_systemd_timer_description: >-
+  Run {{ restic_systemd_unit_name }}.service on schedule
+
+restic_default_environment:
+  RESTIC_REPOSITORY: "{{ restic_repository }}"
+  RESTIC_PASSWORD: "{{ restic_password }}"
+restic_environment: {}
+restic_systemd_environment: >-2
+  {{ restic_default_environment | combine(restic_environment) }}
+
+restic_system_type: "{{ ansible_facts['system'] | lower }}"
+restic_system_arch: >-
+  {{ restic_system_arch_map_ansible_arch[ansible_facts['architecture']] | default('amd64') }}
+restic_system_arch_map_ansible_arch:
+  x86_64: amd64
+  aarch64: arm64
+  arm64: arm64
+  armv6l: arm
+  armv6: arm
+  armv7l: arm
+  armv7: arm
+  armv8l: arm64
+  armv8: arm64
+  i386: 386
+restic_source_server: "github.com"
+restic_source_url: >-2
+  https://{{
+    restic_source_server
+  }}/restic/restic/releases/download/v{{
+    restic_version
+  }}/restic_{{
+    restic_version
+  }}_{{
+    restic_system_type
+  }}_{{
+    restic_system_arch
+  }}.bz2
+restic_source_path: "/tmp/restic-{{ restic_version }}"
+restic_source_archive_path: "{{ restic_source_path }}.bz2"
+
+restic_install_binary: true

--- a/roles/restic/handlers/main.yml
+++ b/roles/restic/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Ensure systemd has reloaded all units
+  ansible.builtin.systemd:
+    daemon_reload: true
+  listen: systemd_daemon_reload

--- a/roles/restic/tasks/main.yml
+++ b/roles/restic/tasks/main.yml
@@ -1,0 +1,99 @@
+---
+- name: Ensure restic is present on system
+  when: restic_install_binary
+  block:
+    - name: Check if restic is available
+      ansible.builtin.stat:
+        path: "{{ restic_binary }}"
+      register: restic_binary_info
+      check_mode: false
+
+    - name: Check if restic is up to date
+      ansible.builtin.command: "{{ restic_binary }} version"
+      register: restic_version_info
+      when: restic_binary_info.stat.exists
+      check_mode: false
+      changed_when: false
+
+    - name: Ensure restic binary is present on host
+      when: "not restic_binary_info.stat.exists or ('restic ' ~ restic_version) not in restic_version_info.stdout"
+      block:
+        - name: Ensure restic release archive is downloaded
+          ansible.builtin.get_url:
+            url: "{{ restic_source_url }}"
+            dest: "{{ restic_source_archive_path }}"
+            url_username: "{{ restic_source_url_http_username | default(omit, true) }}"
+            url_password: "{{ restic_source_url_http_password | default(omit, true) }}"
+            mode: "0600"
+            owner: root
+            group: root
+          register: restic_download
+          until: restic_download is success
+          retries: 5
+          delay: 2
+
+        - name: Unzip latest restic version
+          ansible.builtin.command:
+            cmd: "bunzip2 -d {{ restic_source_archive_path }}"
+            creates: "{{ restic_source_path }}"
+
+        - name: Copy restic binary to /usr/local/bin
+          ansible.builtin.copy:
+            src: "{{ restic_source_path }}"
+            dest: "{{ restic_binary }}"
+            mode: "0755"
+            owner: root
+            group: root
+            remote_src: true
+      always:
+        - name: Ensure all source artifacts are cleaned up
+          ansible.builtin.file:
+            path: "{{ item }}"
+            state: absent
+          loop:
+            - "{{ restic_source_path }}"
+            - "{{ restic_source_archive_path }}"
+
+- name: Fail if no systemd available
+  ansible.builtin.fail:
+    msg: "This role requires systemd to be present for managing the backup service and timer"
+  when: ansible_facts['service_mgr'] != 'systemd'
+  check_mode: false
+
+- name: Ensure restic systemd service is templated
+  ansible.builtin.template:
+    src: restic.service.j2
+    dest: "{{ restic_systemd_unit_file_directory }}/{{ restic_systemd_service_name }}"
+    mode: "0640"
+    owner: "root"
+    group: "root"
+  notify:
+    - systemd_daemon_reload
+
+- name: Ensure restic systemd timer is templated
+  ansible.builtin.template:
+    src: restic.timer.j2
+    dest: "{{ restic_systemd_unit_file_directory }}/{{ restic_systemd_timer_name }}"
+    mode: "0640"
+    owner: "root"
+    group: "root"
+  notify:
+    - systemd_daemon_reload
+
+- name: Ensure handlers are flushed so systemd services are available
+  meta: flush_handlers
+
+- name: Ensure restic systemd service is enabled
+  ansible.builtin.systemd:
+    name: "{{ restic_systemd_service_name }}"
+    enabled: true
+
+- name: Ensure restic systemd timer is enabled
+  ansible.builtin.systemd:
+    name: "{{ restic_systemd_timer_name }}"
+    enabled: true
+
+- name: Ensure restic systemd timer is started
+  ansible.builtin.systemd:
+    name: "{{ restic_systemd_timer_name }}"
+    state: started

--- a/roles/restic/templates/restic.service.j2
+++ b/roles/restic/templates/restic.service.j2
@@ -1,0 +1,27 @@
+[Unit]
+Description={{ restic_job_description }}
+
+[Service]
+Type=oneshot
+User={{ restic_systemd_user }}
+WorkingDirectory={{ restic_systemd_working_directory }}
+SyslogIdentifier={{ restic_systemd_syslog_identifier }}
+
+{% for item in restic_systemd_environment | dict2items %}
+Environment={{ item.key }}={{ item.value }}
+{% endfor %}
+
+ExecStartPre=-/bin/sh -c '{{ restic_binary }} snapshots || {{ restic_binary }} init'
+{% for commands in restic_backup_commands %}
+ExecStart=/bin/sh -c '{{ commands.command }} | {{ restic_binary }} backup --verbose --stdin --stdin-filename {{ commands.filename }}'
+{% endfor %}
+
+{% if restic_backup_paths | length > 0 %}
+ExecStart={{ restic_binary }} --verbose backup {{ restic_backup_paths | join(' ') }}
+{% endif %}
+
+ExecStartPost=-{{ restic_binary }} snapshots
+ExecStartPost={{ restic_binary }} check
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/restic/templates/restic.timer.j2
+++ b/roles/restic/templates/restic.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description={{ restic_systemd_timer_description }}
+
+[Timer]
+OnCalendar={{ restic_systemd_timer_on_calendar }}
+AccuracySec={{ restic_systemd_timer_accuracy_sec }}
+Persistent={{ restic_systemd_timer_persistent | ternary('True', 'False') }}
+Unit={{ restic_systemd_service_name }}
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Resolves https://github.com/famedly/ansible-collection-base/issues/89

Tested cases:
- `restic_install_binary: false` does not attempt to install
- `restic_install_binary` default (true) downloads from GH
  - downloads via nexus if `restic_source_server` set to famedly nexus with HTTP BasicAuth
  - can resume if interrupted (`block`-`always` works and cleans up)