### PR TITLE
fix(secret_storage): gnupg library respects GNUPG_HOME already

### DIFF
--- a/plugins/module_utils/gpg_utils.py
+++ b/plugins/module_utils/gpg_utils.py
@@ -99,7 +99,6 @@ class SecretStore:
         password_store_path: str = "~/.password-store/",
         file_extension: str = ".gpg",
         keyring: str = "pubring.kbx",
-        gnupg_home: str = "~/.gnupg",
         pass_gpg_id_file: str = ".gpg-id",
         recipient_method: str = "pass_file",
         recipient_list: List[str] = None,
@@ -110,7 +109,6 @@ class SecretStore:
 
         # Create gpg object
         self.__gpg = gnupg.GPG(
-            gnupghome=Path(gnupg_home).expanduser().absolute().as_posix(),
             keyring=keyring,
         )
         self.gpg = self.__gpg

--- a/plugins/modules/gpg_secretstore.py
+++ b/plugins/modules/gpg_secretstore.py
@@ -316,7 +316,6 @@ def main():
             keyring=dict(
                 required=False, type="str", default="pubring.kbx", no_log=False
             ),
-            gnupg_home=dict(required=False, type="str", default="~/.gnupg"),
             pass_gpg_id_file=dict(
                 required=False, type="str", default=".gpg-id", no_log=False
             ),
@@ -367,7 +366,6 @@ def main():
         password_store_path=module.params["password_store_path"],
         file_extension=module.params["file_extension"],
         keyring=module.params["keyring"],
-        gnupg_home=module.params["gnupg_home"],
         pass_gpg_id_file=module.params["pass_gpg_id_file"],
     )
 


### PR DESCRIPTION
The gnupg python library uses the $GNUPG_HOME environment variable to detect where the GnuPG home is. Setting a default of `~/.gnupg` which overrides the library behaviour breaks this.