### PR TITLE
check mode fixes

### DIFF
--- a/roles/lego/tasks/main.yml
+++ b/roles/lego/tasks/main.yml
@@ -86,6 +86,7 @@
         group: "{{ lego_user_res.group }}"
         remote_src: true
       tags: ["prepare", "prepare-lego"]
+      when: not ansible_check_mode
 
     - name: "Allow lego to bind to ports below 1024"
       community.general.capabilities:

--- a/roles/user/tasks/user.yml
+++ b/roles/user/tasks/user.yml
@@ -25,3 +25,4 @@
     exclusive: true
   become: true
   when: "user.attrs.active | default(false)"
+  ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
fix(user): ignore ssh key errors in check mode

In check mode, the task fails if it's supposed to be adding ssh keys to a user who doesn't exist. Ignoring errors in check mode makes it possible to run the task in check mode even if there are new users to be added.

fix(lego): don't unpack source files in check mode