### PR TITLE
feat(postgresql): support multiple versions

### DIFF
--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -7,14 +7,6 @@
   register: "postgresql_user_res"
   tags: ["prepare", "prepare-postgresql", "deploy", "deploy-postgresql"]
 
-- name: "Ensure PostgreSQL container image is pulled"
-  community.docker.docker_image:
-    name: "{{ postgresql_container_image_reference }}"
-    force_source: "{{ postgresql_container_pull }}"
-    source: "pull"
-    state: "present"
-  tags: ["prepare", "prepare-postgresql"]
-
 - name: "Check if postgresql_data_path exists"
   stat:
     path: "{{ postgresql_data_path }}"
@@ -27,6 +19,58 @@
     file_type: "any"
   when: "stat_postgresql_data_path.stat.exists"
   register: "find_postgresql_data_path"
+  tags: ["prepare", "prepare-postgresql"]
+
+- name: "Check if container {{ postgresql_container_name }} already exists on host"
+  community.docker.docker_container_info:
+    name: "{{ postgresql_container_name }}"
+  register: "postgresql_active_container"
+  tags: ["prepare", "prepare-postgresql"]
+
+- name: "Set postgresql_active_container_version"
+  ansible.builtin.set_fact:
+    postgresql_active_container_version: >-2
+      {{
+        postgresql_active_container.container.Config.Env
+        | select('search', '^PG_VERSION=')
+        | first
+        | split('=')
+        | last
+        | string
+      }}
+  when: "postgresql_active_container.exists"
+  tags: ["prepare", "prepare-postgresql"]
+
+- name: "Prevent major version update, use version of existing container instead"
+  ansible.builtin.set_fact:
+    postgresql_container_version: "{{ postgresql_active_container_version }}"
+  when:
+    - "postgresql_active_container.exists"
+    - "(postgresql_container_version | int) != (postgresql_active_container_version | int)"
+  tags: ["prepare", "prepare-postgresql"]
+
+- name: "Ensure image {{ postgresql_container_image_reference }} is pulled"
+  community.docker.docker_image:
+    name: "{{ postgresql_container_image_reference }}"
+    force_source: "{{ postgresql_container_pull }}"
+    source: "pull"
+    state: "present"
+  register: "postgresql_image_pulled"
+  tags: ["prepare", "prepare-postgresql"]
+
+- name: "Set container version label to version of pulled image"
+  ansible.builtin.set_fact:
+    postgresql_container_labels_base:
+      version: >-2
+        {{
+          postgresql_image_pulled.image.Config.Env
+          | select('search', '^PG_VERSION=')
+          | first
+          | split('=')
+          | last
+          | string
+        }}
+  when: "postgresql_image_pulled.image.Config is defined"
   tags: ["prepare", "prepare-postgresql"]
 
 - name: "Initialize"


### PR DESCRIPTION
If a container with `postgresql_container_name` exists, only update PostgreSQL to `postgresql_container_version` if the given major version matches the one of the existing container.
Otherwise the version of the existing container will stay unchanged.

preparation for https://github.com/famedly/infra-meta/issues/884