### PR TITLE
openldap 2.6.6-r1 and docker role updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 
 /roles/dns/ @jdreichmann @famedly/infrastructure
 /roles/hostname/ @jdreichmann @famedly/infrastructure
-/roles/ldap/ @jcgruenhage @jdreichmann
+/roles/ldap/ @jcgruenhage @jdreichmann @famedly/infrastructure
 /roles/rclone_serve @evlli @lrsksr @famedly/infrastructure
 /roles/redis/ @jdreichmann @famedly/infrastructure
 /roles/ssh/ @jdreichmann @famedly/infrastructure

--- a/roles/ldap/defaults/main.yml
+++ b/roles/ldap/defaults/main.yml
@@ -4,7 +4,7 @@ ldap_sock_path: "{{ ldap_base_path }}/sock"
 ldap_data_path: "{{ ldap_base_path }}/data"
 ldap_config_path: "{{ ldap_base_path }}/config"
 
-ldap_version: "2.6.5-r0"
+ldap_version: "2.6.6-r1"
 
 ldap_container_image_reference: >-
   {{


### PR DESCRIPTION
- **update(ldap): bump openldap version to 2.6.6-r1**
- **update(docker): bump submodule for debian bookworm support**
