### PR TITLE
fix(restic): use RandomizedDelaySec

### DIFF
--- a/roles/restic/defaults/main.yml
+++ b/roles/restic/defaults/main.yml
@@ -20,7 +20,7 @@ restic_systemd_working_directory: "/tmp"
 restic_systemd_syslog_identifier: "{{ restic_systemd_unit_name }}"
 
 restic_systemd_timer_on_calendar: daily
-restic_systemd_timer_accuracy_sec: 3600
+restic_systemd_timer_randomized_delay_sec: 3600
 restic_systemd_timer_persistent: true
 restic_systemd_timer_description: >-
   Run {{ restic_systemd_unit_name }}.service on schedule

--- a/roles/restic/templates/restic.timer.j2
+++ b/roles/restic/templates/restic.timer.j2
@@ -3,7 +3,7 @@ Description={{ restic_systemd_timer_description }}
 
 [Timer]
 OnCalendar={{ restic_systemd_timer_on_calendar }}
-AccuracySec={{ restic_systemd_timer_accuracy_sec }}
+RandomizedDelaySec={{ restic_systemd_timer_randomized_delay_sec }}
 Persistent={{ restic_systemd_timer_persistent | ternary('True', 'False') }}
 Unit={{ restic_systemd_service_name }}
 


### PR DESCRIPTION
The previously used AccuracySec is the wrong option to distribute timer
activations. See https://www.freedesktop.org/software/systemd/man/latest/systemd.timer.html#RandomizedDelaySec=
