### PR TITLE
refactor: is option initramfs on device needed, also does not select …

### DIFF
--- a/roles/dropbear_luks_unlock/tasks/main.yml
+++ b/roles/dropbear_luks_unlock/tasks/main.yml
@@ -4,14 +4,6 @@
     state: "present"
     pkg: "{{ dropbear_luks_required_packages }}"
 
-- name: "Configure `crypttab`"
-  lineinfile:
-    path: "{{ dropbear_crypttab_path }}"
-    regex: "^(.*) (luks,discard)$"
-    line: "\\1 luks,initramfs"
-    state: "present"
-    backrefs: true
-
 - name: "Configure SSH options for dropbear"
   lineinfile:
     path: "{{ dropbear_initramfs_config_path }}"


### PR DESCRIPTION
…boot device

Selecting a wrong device since it's not matching on the boot device:
```patch
TASK [famedly.base.dropbear_luks_unlock : Configure `crypttab`] *******************************************************
--- before: /etc/crypttab (content)
+++ after: /etc/crypttab (content)
@@ -2,4 +2,4 @@
 luks_sda /dev/sda /root/key_sda.key luks,discard
 luks_sdb /dev/sdb /root/key_sdb.key luks,discard
 luks_sdc /dev/sdc /root/key_sdc.key luks,discard
-luks_sdd /dev/sdd /root/key_sdd.key luks,discard
+luks_sdd /dev/sdd /root/key_sdd.key luks,initramfs
```

https://manpages.debian.org/bookworm/cryptsetup/crypttab.5.en.html lists this as debian-specific, but this server boots fine from `/dev/sde` regardless of `discard` or `initramfs` flag - unclear wether this is needed