### PR TITLE
fix(redis): stop using purge_networks

### DIFF
--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -46,5 +46,4 @@ redis_container_image_force_pull: "{{ redis_container_image_tag is defined }}"
 redis_docker_container_name: "{{ redis_prefix }}redis"
 redis_docker_ports: ["6379:6379"]
 redis_docker_networks: ~
-redis_docker_purge_networks: false
 redis_docker_volumes: ~

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -67,7 +67,6 @@
     volumes: "{{ redis_docker_volumes }}"
     labels: "{{ redis_docker_labels_complete }}"
     networks: "{{ redis_docker_networks | default(omit, True) }}"
-    purge_networks: "{{ redis_docker_purge_networks }}"
     entrypoint: "redis-server"
     command: ["{{ redis_docker_configpath }}"]
     healthcheck:


### PR DESCRIPTION
https://docs.ansible.com/ansible/latest/collections/community/docker/changelog.html#v4-0-0 removed purge_networks, which means newer ansible versions fail to run the redis role at the moment.
