### PR TITLE
chore(postgresql): set address to empty string by default

### DIFF
--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -93,6 +93,7 @@
     users: "postgres"
     method: "peer"
     options: "map=root_postgres"
+    address: ""
   tags: ["prepare", "prepare-postgresql"]
 
 - name: "Insert pg_ident.conf header"

--- a/roles/postgresql_client_access/tasks/main.yml
+++ b/roles/postgresql_client_access/tasks/main.yml
@@ -48,7 +48,7 @@
     users: "{{ item.users | default(omit) }}"
     method: "{{ item.method | default(omit) }}"
     options: "{{ item.options | default(omit) }}"
-    address: "{{ item.address | default(omit) }}"
+    address: "{{ item.address | default('') }}"
     netmask: "{{ item.netmask | default(omit) }}"
     state: "{{ item_state }}"
   loop: "{{ postgresql_client_access_hba_entries }}"


### PR DESCRIPTION
In the newest version of Ansible, the address is set to "samehost" by default, which errors for local connections: https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_pg_hba_module.html#parameter-address