### PR TITLE
fix(famedly-sync): Support hostnames containing dashes

### DIFF
--- a/roles/famedly_sync/tasks/main.yml
+++ b/roles/famedly_sync/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: "Assert config is defined"
   ansible.builtin.assert:
-    that: "famedly_sync_config is defined"
+    that: "hostvars[inventory_hostname]['famedly_sync_config'] is defined"
     fail_msg: "famedly_sync_config needs to be defined per host"
 
 - name: "Create volume path"


### PR DESCRIPTION
ref https://github.com/famedly/infra-meta/issues/2112
tim-test.uke.de has dash and variable didn't pass