### PR TITLE
fix(famedly-sync): Update repo for famedly-sync-agent

### DIFF
--- a/roles/famedly_sync/defaults/main.yml
+++ b/roles/famedly_sync/defaults/main.yml
@@ -23,7 +23,7 @@ famedly_sync_container_image_repository: >-
     + famedly_sync_container_image_namespace | default('')
     + famedly_sync_container_image_name
   }}
-famedly_sync_container_image_registry: "registry.famedly.net/docker-releases"
+famedly_sync_container_image_registry: "registry.famedly.net/docker-oss"
 famedly_sync_container_image_name: "famedly-sync-agent"
 
 famedly_sync_docker_networks:


### PR DESCRIPTION
Ref: https://github.com/famedly/infra-meta/issues/2714

Fixes the pull repo for `famedly-sync-agent`.