### PR TITLE
update(lego): bump version to 4.35.2 INFRA-158

### DIFF
--- a/roles/lego/defaults/main.yml
+++ b/roles/lego/defaults/main.yml
@@ -5,7 +5,7 @@ lego_certificate_store_user: "{{ lego_user_res.uid | default(lego_user) }}"
 lego_certificate_store_group: "{{ lego_user_res.group | default(lego_user) }}"
 lego_certificate_store_mode: "0755"
 lego_systemd_path: "/etc/systemd/system"
-lego_version: "4.35.1"
+lego_version: "4.35.2"
 lego_system_type: "linux"
 lego_system_arch: >-2
   {{


### PR DESCRIPTION
fixes a regression introduced with 4.35.1: https://github.com/go-acme/lego/pull/3020