### PR TITLE
fix(lego_openbao): only restart containers if they exist

### DIFF
--- a/roles/lego_openbao/handlers/main.yml
+++ b/roles/lego_openbao/handlers/main.yml
@@ -19,10 +19,18 @@
   ansible.builtin.systemd:
     daemon_reload: true
 
+- name: Check which restart target containers exist
+  listen: "restart_containers"
+  community.docker.docker_container_info:
+    name: "{{ item }}"
+  register: lego_openbao_restart_container_info
+  changed_when: false
+  loop: "{{ lego_openbao_restart_container_names | default([], true) }}"
+
 - name: Restart containers
   listen: "restart_containers"
   community.docker.docker_container:
-    name: "{{ item }}"
+    name: "{{ item.item }}"
     state: "started"
     restart: true
-  loop: "{{ lego_openbao_restart_container_names | default([], true) }}"
+  loop: "{{ lego_openbao_restart_container_info.results | default([]) | selectattr('exists') | list }}"


### PR DESCRIPTION
While deploying a new host I discovered that this role fails if the containers defined in `lego_openbao_restart_container_names` don't exist, yet.
